### PR TITLE
[Bug] "Infinite" calls in fetching data with InfiniteScroller

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "axios": "^1.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-infinite-scroller": "^1.2.6",
+    "react-infinite-scroll-component": "^6.1.0",
     "vite-plugin-svgr": "^4.2.0",
     "web3-validator": "^2.0.6"
   },

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,7 +7,9 @@ import TransactionLogs from './components/TransactionLogs'
 
 const Layout = styled.div`
   max-width: ${(props) => props.theme.layout.pageWrapperMaxWidth};
+  min-height: 100vh;
   margin: 0 auto;
+  overflow: auto;
 `
 
 function App() {

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -4403,7 +4403,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.8, prop-types@^15.8.1:
+prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -4450,12 +4450,12 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-infinite-scroller@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"
-  integrity sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==
+react-infinite-scroll-component@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-component/-/react-infinite-scroll-component-6.1.0.tgz#7e511e7aa0f728ac3e51f64a38a6079ac522407f"
+  integrity sha512-SQu5nCqy8DxQWpnUVLx7V7b7LcA37aM7tvoWjTLZp1dk6EJibM5/4EJKzOnl07/BsM1Y40sKLuqjCwwH/xV0TQ==
   dependencies:
-    prop-types "^15.5.8"
+    throttle-debounce "^2.1.0"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -4947,6 +4947,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+throttle-debounce@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-2.3.0.tgz#fd31865e66502071e411817e241465b3e9c372e2"
+  integrity sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
### Steps to Reproduce
1. Enter the wallet address `0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5` in the search bar.

**Expected Results:** Users should see ERC-20 token transactions below the search bar.
**Actual Results:** Users see a loader (nonstop requests are made to the API endpoint to fetch the data). 

### Solution
The non-stop calls to the `loadMore` callback function in the `react-infinite-scroller` is a [known issue](https://www.npmjs.com/package/react-infinite-scroller#double-or-non-stop-calls-to-loadmore). I tried applying the fixes recommended in the documentation but ultimately, replaced it with `react-infinite-scroll-component` to resolve the unnecessary calls.

The larger issue is that with the wallet example above, [at least 3800 transaction items](https://etherscan.io/txs?a=0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5&ps=100&p=38) must be grabbed from the Wallet History API before viewing the first instance of an ERC-20 token transaction. We briefly touched on this issue in earlier conversations but to mitigate this issue, we must use the [ERC-20 Token Transfers API](https://docs.moralis.io/web3-data-api/evm/reference/wallet-api/get-wallet-token-transfers?address=0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326&chain=eth&contract_addresses=[]&order=DESC) and then make separate API calls to get the necessary transfer details. This update is not included in this PR.